### PR TITLE
Create requirements.txt, adds pygame and cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pygame
+cryptography


### PR DESCRIPTION
Without this, `python main.py` will give ModuleNotFoundErrors for pygame and cryptography.